### PR TITLE
batch in groups of 10 for stats page query

### DIFF
--- a/baby_words_tracker/lib/pages/stats.dart
+++ b/baby_words_tracker/lib/pages/stats.dart
@@ -198,10 +198,23 @@ Future<List<(int, PartOfSpeech)>> getPartOfSpeechNumWords(
     return cache[(GraphType.wordsByPartOfSpeech, -1, id)];
   }
   Map<PartOfSpeech, int> data = <PartOfSpeech, int>{};
+
   //for the number of days, grab the amount of words learned
   List<WordTracker> allWordsFromChild = await childService.getAllKnownWords(id);
+
+  // Extract all word IDs from trackers
+  List<String> wordIds = allWordsFromChild
+      .where((tracker) => tracker.id != null)
+      .map((tracker) => tracker.id!)
+      .toList();
+
+  // Batch fetch all words
+  List<Word> words = await wordService.getMultipleWords(wordIds);
+
+  Map<String, Word> wordMap = {for (var word in words) word.word: word};
+
   for (var tracker in allWordsFromChild) {
-    Word currWord = await wordService.getWord(tracker.id ?? "invalid id") ??
+    Word currWord = wordMap[tracker.id ?? "invalid id"] ??
         Word(
             word: "Invalid Word",
             languageCodes: <LanguageCode>{},


### PR DESCRIPTION
The previous implementation was making a single query for each word within the child's word tracker. This change batches these in groups of 10 as a simple 90% reduction to reads for the Parent stats page. The researcher portal still has significant query issues, which will be addressed in a future PR.